### PR TITLE
Added MySQL replace directive

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -79,7 +79,7 @@ class Builder
      * @var string[]
      */
     protected $passthru = [
-        'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
+        'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'replace', 'getBindings', 'toSql', 'dump', 'dd',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw', 'getGrammar',
     ];
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2898,6 +2898,46 @@ class Builder
             $this->cleanBindings($bindings)
         );
     }
+    
+    /**
+     * Replace records in the database.
+     *
+     * @param  array  $values
+     * @return int
+     */
+    public function replace(array $values)
+    {
+        // Since every replace gets treated like a batch replace, we will make sure the
+        // bindings are structured in a way that is convenient when building these
+        // replaces statements by verifying these elements are actually an array.
+        if (empty($values)) {
+            return 0;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        // Here, we will sort the replace keys for every record so that each replace is
+        // in the same order for the record. We need to make sure this is the case
+        // so there are not any errors or problems when replacing these records.
+        else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+
+                $values[$key] = $value;
+            }
+        }
+
+        // Finally, we will run this query against the database connection and return
+        // the results. We will need to also flatten these bindings before running
+        // the query so they are all in one huge, flattened array for execution.
+        return $this->connection->update(
+            $this->grammar->compileReplace($this, $values),
+            $this->cleanBindings(Arr::flatten($values, 1))
+        );
+    }
+
 
     /**
      * Update records in the database.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2938,7 +2938,6 @@ class Builder
         );
     }
 
-
     /**
      * Update records in the database.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2898,7 +2898,7 @@ class Builder
             $this->cleanBindings($bindings)
         );
     }
-    
+
     /**
      * Replace records in the database.
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -133,8 +133,7 @@ class MySqlGrammar extends Grammar
 
         return parent::compileInsert($query, $values);
     }
-    
-    
+
     /**
      * Compile an replace statement into SQL. (Only MySQL 8)
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -133,6 +133,19 @@ class MySqlGrammar extends Grammar
 
         return parent::compileInsert($query, $values);
     }
+    
+    
+    /**
+     * Compile an replace statement into SQL. (Only MySQL 8)
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileReplace(Builder $query, array $values)
+    {
+        return Str::replaceFirst('insert', 'replace', $this->compileInsert($query, $values));
+    }
 
     /**
      * Compile the columns for an update statement.

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -135,7 +135,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile an replace statement into SQL. (Only MySQL 8)
+     * Compile an replace statement into SQL. (Only MySQL 8).
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values


### PR DESCRIPTION
This a PR to add support for MySQL REPLACE statement. Docs here: https://dev.mysql.com/doc/refman/8.0/en/replace.html

This will attempt to insert new rows into the table if the primary key or unique keys don't match. Update otherwise.

Side effects users may encounter and not expect, if any of the columns are unique and they THINK they are inserting a new row with any of the unique columns matchings, they will be updating those rows. Unlike insert on duplicate key which would throw an error of a non-unique value, REPLACE would gladly, replace these rows if any or all the UNIQUE columns match. It is not restricted to just the primary key. 

this also means users don't need to pass the primary key to update a row. Like a slug for example, if a user would want to update an article, and have the slug as a unique key, doing a replace passing only the matching unique slug and the new body would correctly update the row.

This could be used to deprecate the upsert(), UpdateOrInsert() function for a more standard approach on MySQL, it wiol not work on other databases from what I am aware of.

Note: this is my first time contributing to laravel, So hello :P Ive been using laravel since 4.1 and loved every second of it, I did have a hard time readjusting to the whole laravel 5 update.